### PR TITLE
Moved babel-polyfill package to app

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -200,7 +200,9 @@ const loaders = [
 */
 
 const app = (() => {
-  const appEntry = [];
+  const appEntry = [
+    path.resolve(NODE_MODULES, 'babel-polyfill'),
+  ];
 
   if (!isDev) {
     appEntry.push(path.resolve(__dirname, 'webpackConfig', 'scripts', 'offline.js'));
@@ -226,7 +228,6 @@ const config = {
   context: path.resolve(themePath),
   entry: {
     common: [
-      path.resolve(NODE_MODULES, 'babel-polyfill'),
       path.resolve(NODE_MODULES, 'intl'),
       path.resolve(NODE_MODULES, 'intl', 'locale-data', 'jsonp', `${isoLang}.js`),
       'react',


### PR DESCRIPTION
Moved babel-polyfill package to be added before the app rather than before common, because the app executes first and runs functionality from common, where the popyfill would be executed too late.