### PR TITLE
Re-enabled source maps in production

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -349,11 +349,11 @@ const config = {
       new TerserPlugin({
         parallel: true,
         extractComments: false,
+        sourceMap: true,
         terserOptions: {
           ecma: 5,
           keep_fnames: false,
           mangle: true,
-          sourceMap: false,
           safari10: false,
           toplevel: false,
           warnings: false,


### PR DESCRIPTION
This PR fixes a misconfiguration of the TerserPlugin which prevented enabling source maps in the live environment.